### PR TITLE
Log scan timer

### DIFF
--- a/src/log_checking/mod.rs
+++ b/src/log_checking/mod.rs
@@ -1,13 +1,17 @@
+use crate::log_upload;
+
 use self::{
     checks::{check_checks, Severity},
     environment::get_environment_info,
 };
 use serenity::all::CreateEmbed;
+use tokio::time::Instant;
 
 pub mod checks;
 pub mod environment;
 
-pub fn check_logs(embed: CreateEmbed, log: &str) -> CreateEmbed {
+pub fn check_logs(log: &str, name: &str, t: &log_upload::LogType) -> CreateEmbed {
+    let start = Instant::now();
     let ctx = get_environment_info(log);
     let checks = check_checks(log, &ctx);
     let severity = checks
@@ -15,17 +19,21 @@ pub fn check_logs(embed: CreateEmbed, log: &str) -> CreateEmbed {
         .map(|r| r.severity)
         .max()
         .unwrap_or(Severity::None);
+    let took = Instant::now() - start;
 
-    let mut embed = embed.color(severity.get_color()).description(format!(
-        "{ctx}{}",
-        if checks.is_empty() {
-            ""
-        } else if matches!(severity, Severity::None) {
-            "\n**More Information:**\n"
-        } else {
-            "\n**Potential Issues Detected:**\n"
-        }
-    ));
+    let mut embed = CreateEmbed::new()
+        .title(t.title_format(name, &took))
+        .color(severity.get_color())
+        .description(format!(
+            "{ctx}{}",
+            if checks.is_empty() {
+                ""
+            } else if matches!(severity, Severity::None) {
+                "\n**More Information:**\n"
+            } else {
+                "\n**Potential Issues Detected:**\n"
+            }
+        ));
 
     for ele in &checks {
         embed = embed.field(format!("- {}", &ele.title), &ele.description, false);


### PR DESCRIPTION
Two things to consider:
* This uses the `Debug` implementation of `Duration`, which has full precision, so it might be a bit annoying to read.
* `Uploaded in xxx` doesn't actually include the web request (due to that information being useless), but I couldn't find a better wording other than `Uploaded; scanned in xxx` which is quite long.